### PR TITLE
Add competence carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,71 @@
   <!-- SKILLS -->
   <section id="skills" class="section-skills container">
     <h2>Compétences</h2>
+
+    <h3>Compétences du B.U.T</h3>
+    <div class="carousel competence-carousel">
+      <button class="carousel-btn prev comp-prev" aria-label="Précédent">&#10094;</button>
+      <div class="competences-grid">
+        <div class="competence-card" data-code="CE1.01 / AC11.04" data-projects="Site sur l’horlogerie">
+          <h4>Développer des interfaces utilisateurs</h4>
+          <p>Algorithme et programmation niveau 1</p>
+        </div>
+        <div class="competence-card" data-code="CE6.01 / AC16.04" data-projects="Site sur l’horlogerie">
+          <h4>Compétences interpersonnelles et intégration</h4>
+          <p>Communication claire et rigueur</p>
+        </div>
+        <div class="competence-card" data-code="CE1.03 / CE1.04" data-projects="Carty">
+          <h4>Conception, qualité, tests et ergonomie</h4>
+          <p>Bonnes pratiques et documentation</p>
+        </div>
+        <div class="competence-card" data-code="CE4.01" data-projects="Carty">
+          <h4>Base de données et sécurité</h4>
+          <p>Requêtes sécurisées et optimisation</p>
+        </div>
+        <div class="competence-card" data-code="CE5.02" data-projects="Carty">
+          <h4>Gestion de projet et suivi</h4>
+          <p>Définition du besoin et planification</p>
+        </div>
+        <div class="competence-card" data-code="CE6.02" data-projects="Carty">
+          <h4>Travail en équipe et suivi</h4>
+          <p>Méthodes collaboratives</p>
+        </div>
+        <div class="competence-card" data-code="CE1.03 / CE1.06" data-projects="Blackjack">
+          <h4>Algorithmes et coding</h4>
+          <p>Gestion de la logique du jeu</p>
+        </div>
+        <div class="competence-card" data-code="CE2.01" data-projects="Blackjack">
+          <h4>Optimisation</h4>
+          <p>Structuration et performances</p>
+        </div>
+        <div class="competence-card" data-code="CE5.01" data-projects="Blackjack">
+          <h4>Rigueur projet</h4>
+          <p>Démarche proactive</p>
+        </div>
+        <div class="competence-card" data-code="CE1.01 / CE1.03" data-projects="Fou2Food">
+          <h4>Développement complet applicatif</h4>
+          <p>Backend, frontend et tests</p>
+        </div>
+        <div class="competence-card" data-code="CE3.01" data-projects="Fou2Food">
+          <h4>Sécurisation et déploiement</h4>
+          <p>Mise en ligne et protection des données</p>
+        </div>
+        <div class="competence-card" data-code="CE4.01–CE4.03" data-projects="Fou2Food">
+          <h4>Gestion et sécurité de la BD</h4>
+          <p>Schéma, requêtes et restitution</p>
+        </div>
+        <div class="competence-card" data-code="CE5.01–CE5.04" data-projects="Fou2Food">
+          <h4>Pilotage et gestion de projet</h4>
+          <p>Spécification et suivi</p>
+        </div>
+        <div class="competence-card" data-code="CE6.01–CE6.04" data-projects="Fou2Food">
+          <h4>Travail en équipe et communication</h4>
+          <p>Gestion de versions et évolution</p>
+        </div>
+      </div>
+      <button class="carousel-btn next comp-next" aria-label="Suivant">&#10095;</button>
+    </div>
+
     <ul class="skills-list">
       <li>PHP</li>
       <li>Symfony</li>
@@ -93,6 +158,14 @@
       <li>Java</li>
       <li>Python</li>
     </ul>
+
+    <div id="competence-modal" class="modal hidden">
+      <div class="modal-content">
+        <span class="modal-close">&times;</span>
+        <h4 id="modal-title"></h4>
+        <ul id="modal-project-list"></ul>
+      </div>
+    </div>
   </section>
 
   <!-- FOOTER -->

--- a/script.js
+++ b/script.js
@@ -23,3 +23,56 @@ if (track && prevBtn && nextBtn) {
     track.scrollBy({ left: scrollAmount(), behavior: 'smooth' });
   });
 }
+
+// Competence carousel
+const compTrack = document.querySelector('.competences-grid');
+const compPrev = document.querySelector('.carousel-btn.comp-prev');
+const compNext = document.querySelector('.carousel-btn.comp-next');
+
+if (compTrack && compPrev && compNext) {
+  const cCard = compTrack.querySelector('.competence-card');
+  const compScrollAmount = () => (cCard ? cCard.offsetWidth + 32 : 300);
+
+  compPrev.addEventListener('click', () => {
+    compTrack.scrollBy({ left: -compScrollAmount(), behavior: 'smooth' });
+  });
+
+  compNext.addEventListener('click', () => {
+    compTrack.scrollBy({ left: compScrollAmount(), behavior: 'smooth' });
+  });
+}
+
+// Modal for competence projects
+const modal = document.getElementById('competence-modal');
+const modalTitle = document.getElementById('modal-title');
+const modalList = document.getElementById('modal-project-list');
+const modalClose = document.querySelector('.modal-close');
+
+document.querySelectorAll('.competence-card').forEach(card => {
+  card.addEventListener('click', () => {
+    modalTitle.textContent = `${card.dataset.code} - ${card.querySelector('h4').textContent}`;
+    modalList.innerHTML = '';
+    const projects = card.dataset.projects.split(',').map(p => p.trim());
+    projects.forEach(p => {
+      const li = document.createElement('li');
+      li.textContent = p;
+      modalList.appendChild(li);
+    });
+    modal.classList.add('show');
+    modal.classList.remove('hidden');
+  });
+});
+
+if (modalClose) {
+  modalClose.addEventListener('click', () => {
+    modal.classList.remove('show');
+  });
+}
+
+if (modal) {
+  modal.addEventListener('click', e => {
+    if (e.target === modal) {
+      modal.classList.remove('show');
+    }
+  });
+}

--- a/style.css
+++ b/style.css
@@ -122,8 +122,8 @@ body {
   border: 1px solid #e0e0e0;
   border-radius: 8px;
   padding: 1rem;
-  flex: 0 0 80%;
-  max-width: 300px;
+  flex: 0 0 100%;
+  max-width: 100%;
   scroll-snap-align: center;
   margin: 0 1rem;
   transition: transform 0.3s;
@@ -153,6 +153,69 @@ body {
   padding: 0.5rem 1rem;
   border-radius: 20px;
 }
+
+.competences-grid {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  gap: 1rem;
+  padding: 1rem 0;
+}
+
+.competence-card {
+  background: #f9f9f9;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 1rem;
+  flex: 0 0 100%;
+  max-width: 100%;
+  scroll-snap-align: center;
+  margin: 0 1rem;
+  cursor: pointer;
+  transition: transform 0.3s;
+}
+
+.competence-card:hover {
+  transform: translateY(-5px);
+}
+
+.modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  align-items: center;
+  justify-content: center;
+}
+
+.modal.show {
+  display: flex;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 90%;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 10px;
+  right: 20px;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.hidden {
+  display: none;
+}
 .site-footer {
   text-align: center;
   padding: 1rem 0;
@@ -177,7 +240,7 @@ body {
   }
 
   .project-card {
-    flex: 0 0 90%;
+    flex: 0 0 100%;
     margin: 0 auto;
   }
 


### PR DESCRIPTION
## Summary
- add carousel for B.U.T. competences
- open modal listing related projects
- move competence carousel above skills list
- show one card at a time for both carousels

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853c4d7f6cc832093c6a80ab39d0250