### PR TITLE
Enable looping carousels and restore layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,15 +85,6 @@
   <!-- SKILLS -->
   <section id="skills" class="section-skills container">
     <h2>Compétences</h2>
-    <ul class="skills-list">
-      <li>PHP</li>
-      <li>Symfony</li>
-      <li>JavaScript</li>
-      <li>HTML & CSS</li>
-      <li>Java</li>
-      <li>Python</li>
-    </ul>
-
     <h3>Compétences du B.U.T</h3>
     <div class="carousel competence-carousel">
       <button class="carousel-btn prev comp-prev" aria-label="Précédent">&#10094;</button>
@@ -157,6 +148,15 @@
       </div>
       <button class="carousel-btn next comp-next" aria-label="Suivant">&#10095;</button>
     </div>
+
+    <ul class="skills-list">
+      <li>PHP</li>
+      <li>Symfony</li>
+      <li>JavaScript</li>
+      <li>HTML & CSS</li>
+      <li>Java</li>
+      <li>Python</li>
+    </ul>
 
     <div id="competence-modal" class="modal hidden">
       <div class="modal-content">

--- a/script.js
+++ b/script.js
@@ -12,15 +12,24 @@ const prevBtn = document.querySelector('.carousel-btn.prev');
 const nextBtn = document.querySelector('.carousel-btn.next');
 
 if (track && prevBtn && nextBtn) {
-  const card = track.querySelector('.project-card');
-  const scrollAmount = () => (card ? card.offsetWidth + 32 : 300);
+  const cards = track.querySelectorAll('.project-card');
+  let index = 0;
+
+  const scrollToCard = () => {
+    const card = cards[index];
+    if (card) {
+      track.scrollTo({ left: card.offsetLeft, behavior: 'smooth' });
+    }
+  };
 
   prevBtn.addEventListener('click', () => {
-    track.scrollBy({ left: -scrollAmount(), behavior: 'smooth' });
+    index = (index - 1 + cards.length) % cards.length;
+    scrollToCard();
   });
 
   nextBtn.addEventListener('click', () => {
-    track.scrollBy({ left: scrollAmount(), behavior: 'smooth' });
+    index = (index + 1) % cards.length;
+    scrollToCard();
   });
 }
 
@@ -30,15 +39,24 @@ const compPrev = document.querySelector('.carousel-btn.comp-prev');
 const compNext = document.querySelector('.carousel-btn.comp-next');
 
 if (compTrack && compPrev && compNext) {
-  const cCard = compTrack.querySelector('.competence-card');
-  const compScrollAmount = () => (cCard ? cCard.offsetWidth + 32 : 300);
+  const cards = compTrack.querySelectorAll('.competence-card');
+  let index = 0;
+
+  const scrollToCard = () => {
+    const card = cards[index];
+    if (card) {
+      compTrack.scrollTo({ left: card.offsetLeft, behavior: 'smooth' });
+    }
+  };
 
   compPrev.addEventListener('click', () => {
-    compTrack.scrollBy({ left: -compScrollAmount(), behavior: 'smooth' });
+    index = (index - 1 + cards.length) % cards.length;
+    scrollToCard();
   });
 
   compNext.addEventListener('click', () => {
-    compTrack.scrollBy({ left: compScrollAmount(), behavior: 'smooth' });
+    index = (index + 1) % cards.length;
+    scrollToCard();
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -122,8 +122,8 @@ body {
   border: 1px solid #e0e0e0;
   border-radius: 8px;
   padding: 1rem;
-  flex: 0 0 80%;
-  max-width: 300px;
+  flex: 0 0 100%;
+  max-width: 100%;
   scroll-snap-align: center;
   margin: 0 1rem;
   transition: transform 0.3s;
@@ -168,8 +168,8 @@ body {
   border: 1px solid #e0e0e0;
   border-radius: 8px;
   padding: 1rem;
-  flex: 0 0 80%;
-  max-width: 300px;
+  flex: 0 0 100%;
+  max-width: 100%;
   scroll-snap-align: center;
   margin: 0 1rem;
   cursor: pointer;
@@ -240,7 +240,7 @@ body {
   }
 
   .project-card {
-    flex: 0 0 90%;
+    flex: 0 0 100%;
     margin: 0 auto;
   }
 


### PR DESCRIPTION
## Summary
- restore single-item layout for project and competency cards
- move B.U.T. competency list ahead of the skill chips
- loop the project and competency carousels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853c984b8a48320946a566c0aaf25e3