### PR TITLE
Fix competence modal layering

### DIFF
--- a/style.css
+++ b/style.css
@@ -189,6 +189,7 @@ body {
   background: rgba(0, 0, 0, 0.5);
   align-items: center;
   justify-content: center;
+  z-index: 1000;
 }
 
 .modal.show {


### PR DESCRIPTION
## Summary
- ensure the competence modal appears above other elements by setting a high `z-index`

## Testing
- `grep -n "z-index" -n style.css`

------
https://chatgpt.com/codex/tasks/task_e_6853cf83e858832084c6c30ef6fb8958